### PR TITLE
feat: SwiftUI - Readable Content Guideline modifier

### DIFF
--- a/Sources/GoodSwiftUI/ReadableContentWidthModifier.swift
+++ b/Sources/GoodSwiftUI/ReadableContentWidthModifier.swift
@@ -31,8 +31,9 @@ private struct ReadableContentWidth: ViewModifier {
 
 public extension View {
 
-    func readableContentWidth() -> some View {
-        modifier(ReadableContentWidth())
+    func readableContentWidth(_ edges: Edge.Set = .horizontal, _ length: CGFloat = 16) -> some View {
+        let modifiedView = modifier(ReadableContentWidth())
+        return modifiedView.padding(edges, length)
     }
 
 }

--- a/Sources/GoodSwiftUI/ReadableContentWidthModifier.swift
+++ b/Sources/GoodSwiftUI/ReadableContentWidthModifier.swift
@@ -1,0 +1,38 @@
+//
+//  ReadableContentWidthModifier.swift
+//
+//  GoodSwiftUI
+//  Created by Filip Šašala on 31/12/2023.
+//
+
+import SwiftUI
+
+private struct ReadableContentWidth: ViewModifier {
+
+    private let measureViewController = UIViewController()
+
+    @State private var orientation: UIDeviceOrientation = UIDevice.current.orientation
+
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: readableWidth(for: orientation))
+            .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+                orientation = UIDevice.current.orientation
+            }
+    }
+
+    private func readableWidth(for _: UIDeviceOrientation) -> CGFloat {
+        measureViewController.view.frame = UIScreen.main.bounds
+        let readableContentSize = measureViewController.view.readableContentGuide.layoutFrame.size
+        return readableContentSize.width
+    }
+
+}
+
+public extension View {
+
+    func readableContentWidth() -> some View {
+        modifier(ReadableContentWidth())
+    }
+
+}


### PR DESCRIPTION
SwiftUI nema sposob, ako obmedzit sirku contentu na citatelnu sirku, co v UIKite bolo mozne pomocou `readableContentGuide`.

Tento PR pridava modifier `.readableContentWidth()`. Pouzitie:

```swift
var body: some View {
    ScrollView {
        VStack {
            scrollContent
        }
        .readableContentWidth()
    }
}
```

Priklad:
![ipad](https://github.com/GoodRequest/GoodSwiftUI/assets/31418257/5dd30c23-af96-4460-a263-dd6291696e38)
