### PR TITLE
fix: Add option to not reload async image

### DIFF
--- a/Sources/GRAsyncImage/GRAsyncImage.swift
+++ b/Sources/GRAsyncImage/GRAsyncImage.swift
@@ -17,6 +17,7 @@ public struct GRAsyncImage<FailurePlaceholder: View, LoadingPlaceholder: View>: 
     var url: URL?
     var failurePlaceholder: FailurePlaceholder
     var loadingPlaceholder: LoadingPlaceholder
+    var reloadingIsAllowed: Bool
     var onLoading: VoidClosure?
     var onSuccess: VoidClosure?
     var onFailure: VoidClosure?
@@ -27,6 +28,7 @@ public struct GRAsyncImage<FailurePlaceholder: View, LoadingPlaceholder: View>: 
         url: URL?,
         @ViewBuilder failurePlaceholder: () -> FailurePlaceholder = { Image(systemName: "arrow.clockwise") },
         @ViewBuilder loadingPlaceholder: () -> LoadingPlaceholder = { ProgressView().progressViewStyle(.circular) },
+        reloadingIsAllowed: Bool = true,
         onLoading: VoidClosure? = nil,
         onSuccess: VoidClosure? = nil,
         onFailure: VoidClosure? = nil
@@ -36,6 +38,7 @@ public struct GRAsyncImage<FailurePlaceholder: View, LoadingPlaceholder: View>: 
         self.url = url
         self.failurePlaceholder = failurePlaceholder()
         self.loadingPlaceholder = loadingPlaceholder()
+        self.reloadingIsAllowed = reloadingIsAllowed
         self.onLoading = onLoading
         self.onSuccess = onSuccess
         self.onFailure = onFailure
@@ -58,7 +61,11 @@ public struct GRAsyncImage<FailurePlaceholder: View, LoadingPlaceholder: View>: 
                 }
 
             case .failure:
-                Button(action: { loadImage(url: url) }, label: { failurePlaceholder })
+                if let url, reloadingIsAllowed {
+                    Button(action: { loadImage(url: url) }, label: { failurePlaceholder })
+                } else {
+                    failurePlaceholder
+                }
 
             case .idle:
                 Color.clear


### PR DESCRIPTION
The async image is always clickable when no image is loaded, even when no URL is provided. I have added support to disable reloading, so the button is not always clickable.