### PR TITLE
Isolate validation to main thread + fix error localizations

### DIFF
--- a/GoodSwiftUI-Sample/GoodSwiftUI-Sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GoodSwiftUI-Sample/GoodSwiftUI-Sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b46379685bdd89847bab0c4df516d7df815c27bd0571dd4246fe2285ce20a8fc",
+  "originHash" : "5a3e29e9f54eef0b3f74b7a499302ccb3ef302ad2bf45cf1964b5ba7f8a6ff8c",
   "pins" : [
     {
       "identity" : "combineext",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/goodrequest/goodextensions-ios",
       "state" : {
-        "revision" : "dd6fe6484a87f4ccde73136d491b2339e2a3ab98",
-        "version" : "2.0.0"
+        "revision" : "d06f82844f041c6d8d1462753c9ce6bb069ec976",
+        "version" : "2.0.2"
       }
     },
     {

--- a/GoodSwiftUI-Sample/GoodSwiftUI-Sample/Screens/InputFieldSampleView.swift
+++ b/GoodSwiftUI-Sample/GoodSwiftUI-Sample/Screens/InputFieldSampleView.swift
@@ -154,6 +154,15 @@ extension InputFieldSampleView {
             placeholder: "0 %"
         )
         .inputFieldTraits(keyboardType: .numbersAndPunctuation)
+        .onSubmit {
+            print("Submit action")
+        }
+        .onResign {
+            print("Resign action")
+        }
+        .onEditingChanged {
+            print("Value changed")
+        }
     }
 
     private var customViewsInputField: some View {

--- a/GoodSwiftUI-Sample/GoodSwiftUI-Sample/Screens/InputFieldSampleView.swift
+++ b/GoodSwiftUI-Sample/GoodSwiftUI-Sample/Screens/InputFieldSampleView.swift
@@ -16,7 +16,7 @@ struct InputFieldSampleView: View {
         case notFilip
         case pinTooShort
 
-        var localizedDescription: String {
+        var errorDescription: String? {
             switch self {
             case .notFilip:
                 "Your name is not Filip"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "94efdbf22edf468a2bb6786e7222850c56322e1980edc13a655dcb9219ca1400",
+  "originHash" : "5a3e29e9f54eef0b3f74b7a499302ccb3ef302ad2bf45cf1964b5ba7f8a6ff8c",
   "pins" : [
     {
       "identity" : "combineext",
@@ -13,10 +13,10 @@
     {
       "identity" : "goodextensions-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/goodrequest/goodextensions-ios",
+      "location" : "https://github.com/GoodRequest/GoodExtensions-iOS.git",
       "state" : {
-        "revision" : "dd6fe6484a87f4ccde73136d491b2339e2a3ab98",
-        "version" : "2.0.0"
+        "revision" : "d06f82844f041c6d8d1462753c9ce6bb069ec976",
+        "version" : "2.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/goodrequest/goodextensions-ios", .upToNextMajor(from: "2.0.0"))
+        .package(url: "https://github.com/GoodRequest/GoodExtensions-iOS.git", .upToNextMajor(from: "2.0.2"))
     ],
     targets: [
         .target(

--- a/Sources/GRInputField/Common/ValidationError.swift
+++ b/Sources/GRInputField/Common/ValidationError.swift
@@ -10,7 +10,7 @@ import GoodExtensions
 
 // MARK: - Validation errors
 
-public protocol ValidationError: Error, Equatable {
+@MainActor public protocol ValidationError: Error {
 
     var localizedDescription: String { get }
 
@@ -21,7 +21,7 @@ public enum InternalValidationError: ValidationError {
     case alwaysError
     case required
     case mismatch
-    case external(String)
+    case external(MainSupplier<String>)
 
     public var localizedDescription: String {
         switch self {
@@ -35,7 +35,7 @@ public enum InternalValidationError: ValidationError {
             "Elements do not match"
 
         case .external(let description):
-            description
+            description()
         }
     }
 
@@ -46,18 +46,18 @@ public enum InternalValidationError: ValidationError {
 public extension Criterion {
 
     /// Always succeeds
-    nonisolated static let alwaysValid = Criterion { _ in true }
+    static let alwaysValid = Criterion { _ in true }
 
     /// Always fails
-    nonisolated static let alwaysError = Criterion { _ in false }
+    static let alwaysError = Criterion { _ in false }
         .failWith(error: InternalValidationError.alwaysError)
 
     /// Accepts any input with length > 0, excluding leading/trailing whitespace
-    nonisolated static let nonEmpty = Criterion { !($0 ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    static let nonEmpty = Criterion { !($0 ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
         .failWith(error: InternalValidationError.required)
 
     /// Accepts an input if it is equal with another input
-    nonisolated static func matches(_ other: String?) -> Criterion {
+    static func matches(_ other: String?) -> Criterion {
         Criterion { this in this == other }
             .failWith(error: InternalValidationError.mismatch)
     }
@@ -69,14 +69,14 @@ public extension Criterion {
     ///
     /// If input is empty, validation **succeeds** and input is deemed valid.
     /// If input is non-empty, validation continues by criterion specified as a parameter.
-    nonisolated static func acceptEmpty(_ criterion: Criterion) -> Criterion {
+    static func acceptEmpty(_ criterion: Criterion) -> Criterion {
         Criterion { Criterion.nonEmpty.validate(input: $0) ? criterion.validate(input: $0) : true }
             .failWith(error: criterion.error)
     }
 
-    nonisolated static func external(error: @autoclosure @escaping Supplier<(any Error)?>) -> Criterion {
+    static func external(error: @MainActor @escaping () -> (any Error)?) -> Criterion {
         Criterion { _ in error().isNil }
-            .failWith(error: InternalValidationError.external(error()?.localizedDescription ?? " "))
+            .failWith(error: InternalValidationError.external { error()?.localizedDescription ?? " " })
     }
 
 }

--- a/Sources/GRInputField/Common/Validator.swift
+++ b/Sources/GRInputField/Common/Validator.swift
@@ -11,7 +11,7 @@ import GoodStructs
 
 // MARK: - ValidatorBuilder
 
-@resultBuilder public struct ValidatorBuilder {
+@MainActor @resultBuilder public struct ValidatorBuilder {
 
     public static func buildBlock(_ components: CriteriaConvertible...) -> Validator {
         var criteria: [Criterion] = []
@@ -48,15 +48,15 @@ import GoodStructs
 
 // MARK: - Validator
 
-public struct Validator: CriteriaConvertible {
+@MainActor public struct Validator: CriteriaConvertible {
 
-    fileprivate var criteria: [Criterion] = []
+    internal var criteria: [Criterion] = []
 
-    @MainActor public func isValid(input: String?) -> Bool {
+    public func isValid(input: String?) -> Bool {
         validate(input: input).isNil
     }
 
-    @MainActor public func validate(input: String?) -> (any ValidationError)? {
+    public func validate(input: String?) -> (any ValidationError)? {
         let failedCriterion = criteria
             .map { (criterion: $0, result: $0.validate(input: input)) }
             .first { _, result in !result }
@@ -77,7 +77,7 @@ public struct Validator: CriteriaConvertible {
 
 // MARK: - Criterion
 
-public struct Criterion: Sendable, Then, CriteriaConvertible {
+@MainActor public struct Criterion: Sendable, Then, CriteriaConvertible {
 
     // MARK: - Variables
 
@@ -114,7 +114,7 @@ public struct Criterion: Sendable, Then, CriteriaConvertible {
 
 // MARK: - CriteriaConvertible
 
-public protocol CriteriaConvertible {
+@MainActor public protocol CriteriaConvertible {
 
     func asCriteria() -> [Criterion]
 
@@ -124,11 +124,11 @@ public protocol CriteriaConvertible {
 
 extension Criterion: Hashable {
 
-    public static func == (lhs: Criterion, rhs: Criterion) -> Bool {
+    nonisolated public static func == (lhs: Criterion, rhs: Criterion) -> Bool {
         lhs.hashValue == rhs.hashValue
     }
 
-    public func hash(into hasher: inout Hasher) {
+    nonisolated public func hash(into hasher: inout Hasher) {
         if predicate.isNotNil { hasher.combine(UUID()) }
         hasher.combine(regex)
     }

--- a/Sources/GRInputField/SwiftUI/InputField.swift
+++ b/Sources/GRInputField/SwiftUI/InputField.swift
@@ -318,6 +318,10 @@ public struct InputField<LeftView: View, RightView: View>: UIViewRepresentable {
             return syncValidationState(uiViewState: .pending(error: validationError), context: context)
         }
 
+        guard newValidationState != previousValidationState else {
+            return
+        }
+
         changeValidationState(to: newValidationState, uiView: uiView, context: context)
     }
 

--- a/Sources/GRInputField/SwiftUI/InputField.swift
+++ b/Sources/GRInputField/SwiftUI/InputField.swift
@@ -36,7 +36,7 @@ public struct InputField<LeftView: View, RightView: View>: UIViewRepresentable {
 
     private var traits: InputFieldTraits
     private var allowedInput: Regex?
-    @ValidatorBuilder private var criteria: Supplier<Validator>
+    @ValidatorBuilder private var criteria: MainSupplier<Validator>
     private var focusAction: MainClosure?
     private var submitAction: MainClosure?
     private var resignAction: MainClosure?
@@ -58,14 +58,7 @@ public struct InputField<LeftView: View, RightView: View>: UIViewRepresentable {
         self.placeholder = placeholder
         self.hint = hint
         self.traits = InputFieldTraits()
-
-        @ValidatorBuilder @Sendable func alwaysValidCriteria() -> Validator {
-            Criterion.alwaysValid
-        }
-
-        // closures cannot take @ValidationBuilder attribute, must be a function reference
-        self.criteria = alwaysValidCriteria
-
+        self.criteria = { Validator(criteria: [Criterion.alwaysValid]) }
         self.leftView = leftView
         self.rightView = rightView
     }
@@ -325,10 +318,6 @@ public struct InputField<LeftView: View, RightView: View>: UIViewRepresentable {
             return syncValidationState(uiViewState: .pending(error: validationError), context: context)
         }
 
-        guard newValidationState != previousValidationState else {
-            return
-        }
-
         changeValidationState(to: newValidationState, uiView: uiView, context: context)
     }
 
@@ -373,25 +362,25 @@ public extension InputField {
         return modifiedSelf
     }
 
-    func onResign(_ action: @escaping VoidClosure) -> Self {
+    func onResign(_ action: @escaping MainClosure) -> Self {
         var modifiedSelf = self
         modifiedSelf.resignAction = action
         return modifiedSelf
     }
 
-    func onSubmit(_ action: @escaping VoidClosure) -> Self {
+    func onSubmit(_ action: @escaping MainClosure) -> Self {
         var modifiedSelf = self
         modifiedSelf.submitAction = action
         return modifiedSelf
     }
 
-    func onEditingChanged(_ action: @escaping VoidClosure) -> Self {
+    func onEditingChanged(_ action: @escaping MainClosure) -> Self {
         var modifiedSelf = self
         modifiedSelf.editingChangedAction = action
         return modifiedSelf
     }
 
-    func validationCriteria(@ValidatorBuilder _ criteria: @escaping Supplier<Validator>) -> Self {
+    func validationCriteria(@ValidatorBuilder _ criteria: @escaping MainSupplier<Validator>) -> Self {
         var modifiedSelf = self
         modifiedSelf.criteria = criteria
         return modifiedSelf
@@ -426,7 +415,6 @@ public extension InputField {
     func allowedInput(_ allowedInputRegex: Regex?) -> Self {
         var modifiedSelf = self
         modifiedSelf.allowedInput = allowedInputRegex
-
         return modifiedSelf
     }
 

--- a/Sources/GRInputField/SwiftUI/ValidityGroup.swift
+++ b/Sources/GRInputField/SwiftUI/ValidityGroup.swift
@@ -25,7 +25,7 @@ public typealias ValidityGroup = [UUID: ValidationState]
 
 // MARK: - Validation State
 
-@MainActor public enum ValidationState: Sendable {
+@MainActor public enum ValidationState: Sendable, Equatable {
 
     case valid
     case error(any ValidationError)
@@ -53,6 +53,25 @@ public typealias ValidityGroup = [UUID: ValidationState]
             } else {
                 return .valid
             }
+        }
+    }
+
+    nonisolated public static func == (lhs: ValidationState, rhs: ValidationState) -> Bool {
+        switch (lhs, rhs) {
+        case (.valid, .valid):
+            return true
+
+        case (.invalid, .invalid):
+            return true
+
+        case (.error(let lhsValidationError), .error(let rhsValidationError)):
+            return lhsValidationError.localizedDescription == rhsValidationError.localizedDescription
+
+        case (.pending(let lhsValidationError), .pending(let rhsValidationError)):
+            return lhsValidationError?.localizedDescription == rhsValidationError?.localizedDescription
+
+        default:
+            return false
         }
     }
 

--- a/Sources/GRInputField/SwiftUI/ValidityGroup.swift
+++ b/Sources/GRInputField/SwiftUI/ValidityGroup.swift
@@ -11,7 +11,7 @@ import Foundation
 
 public typealias ValidityGroup = [UUID: ValidationState]
 
-public extension ValidityGroup {
+@MainActor public extension ValidityGroup {
 
     func allValid() -> Bool {
         isEmpty ? false : allSatisfy { $0.value.isValid }
@@ -25,7 +25,7 @@ public extension ValidityGroup {
 
 // MARK: - Validation State
 
-public enum ValidationState: Equatable, Sendable {
+@MainActor public enum ValidationState: Sendable {
 
     case valid
     case error(any ValidationError)
@@ -52,39 +52,6 @@ public enum ValidationState: Equatable, Sendable {
                 return .error(error)
             } else {
                 return .valid
-            }
-        }
-    }
-
-    public static func == (lhs: ValidationState, rhs: ValidationState) -> Bool {
-        switch lhs {
-        case .valid:
-            switch rhs {
-            case .valid:
-                return true
-            default:
-                return false
-            }
-        case .error(let lhsValidationError):
-            switch rhs {
-            case .error(let rhsValidationError):
-                return lhsValidationError.localizedDescription == rhsValidationError.localizedDescription
-            default:
-                return false
-            }
-        case .pending(let lhsValidationError):
-            switch rhs {
-            case .pending(let rhsValidationError):
-                return lhsValidationError?.localizedDescription == rhsValidationError?.localizedDescription
-            default:
-                return false
-            }
-        case .invalid:
-            switch rhs {
-            case .invalid:
-                return true
-            default:
-                return false
             }
         }
     }


### PR DESCRIPTION
- Validation isolated to MainActor
- ValidationError now uses `LocalizedError` as a base instead of `any Error` - this means that localization description does not depend on ObjC NSError & dynamic/static dispatch types, and always uses the correct localization from `errorDescription: String?`.

note: DO NOT call `errorDescription` directly, instead always read the localization from `localizedDescription`. The culprit behind this weird behaviour is Swift's Error type.