### PR TITLE
Localized validation strings

### DIFF
--- a/Sources/GRInputField/Common/ValidationError.swift
+++ b/Sources/GRInputField/Common/ValidationError.swift
@@ -14,21 +14,21 @@ public protocol ValidationError: LocalizedError {}
 
 public enum InternalValidationError: ValidationError {
 
-    case alwaysError
+    case invalid
     case required
     case mismatch
     case external(MainSupplier<String>)
 
     public var errorDescription: String? {
         switch self {
-        case .alwaysError:
-            "Error"
+        case .invalid:
+            Bundle.main.localizedString(forKey: "invalid", value: "Invalid", table: "InternalValidationError")
 
         case .required:
-            "Required"
+            Bundle.main.localizedString(forKey: "required", value: "Required", table: "InternalValidationError")
 
         case .mismatch:
-            "Elements do not match"
+            Bundle.main.localizedString(forKey: "mismatch", value: "Mismatch", table: "InternalValidationError")
 
         case .external(let description):
             MainActor.assumeIsolated {
@@ -48,7 +48,7 @@ public extension Criterion {
 
     /// Always fails
     static let alwaysError = Criterion { _ in false }
-        .failWith(error: InternalValidationError.alwaysError)
+        .failWith(error: InternalValidationError.invalid)
 
     /// Accepts any input with length > 0, excluding leading/trailing whitespace
     static let nonEmpty = Criterion { !($0 ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }

--- a/Sources/GRInputField/Common/Validator.swift
+++ b/Sources/GRInputField/Common/Validator.swift
@@ -81,7 +81,7 @@ import GoodStructs
 
     // MARK: - Variables
 
-    private(set) internal var error: any ValidationError = InternalValidationError.alwaysError
+    private(set) internal var error: any ValidationError = InternalValidationError.invalid
 
     // MARK: - Constants
 

--- a/Sources/GRInputField/UIKit/ValidableInputFieldView.swift
+++ b/Sources/GRInputField/UIKit/ValidableInputFieldView.swift
@@ -68,7 +68,7 @@ public class ValidableInputFieldView: InputFieldView {
     /// Does not update the UI in any way.
     /// - Returns: `nil` when content is valid, otherwise validation error from failed criterion.
     public func validateSilently() -> (any ValidationError)? {
-        guard let validator = validator?() else { return InternalValidationError.alwaysError }
+        guard let validator = validator?() else { return InternalValidationError.invalid }
 
         return validator.validate(input: self.text)
     }


### PR DESCRIPTION
Validation error messages are now localized natively, without having to override the default localization using `.failWith(:)`.

Usage:
- Create localization table `InternalValidationError.strings` in the main executable's bundle
- Add matching keys and localize them

<img width="350" alt="image" src="https://github.com/user-attachments/assets/0ad8159c-c002-440c-819c-fc05a5a9215d"></img>

Result:
<img width="350" src="https://github.com/user-attachments/assets/b7ab1278-0299-418b-8eca-352613efa8d9"></img>
