### PR TITLE
feat: Support local appearance configuration 

### DIFF
--- a/GoodSwiftUI-Sample/GoodSwiftUI-Sample/Extensions/InputFieldViewConfiguration.swift
+++ b/GoodSwiftUI-Sample/GoodSwiftUI-Sample/Extensions/InputFieldViewConfiguration.swift
@@ -11,7 +11,7 @@ import GRInputField
 extension InputFieldView {
 
     static func configureAppearance() {
-        let customAppearance = InputFieldAppearance(
+        let globalAppearance = InputFieldAppearance(
             titleFont: UIFont.preferredFont(for: .caption1, weight: .regular, defaultSize: 12.0),
             titleColor: UIColor.systemBlue,
             textFieldTintColor: UIColor.systemBlue,
@@ -33,14 +33,14 @@ extension InputFieldView {
                 placeholderColor: UIColor.darkGray,
                 contentBackgroundColor: UIColor.tertiarySystemBackground,
                 textFieldTextColor: UIColor.systemBlue,
-                borderColor: UIColor.gray,
+                borderColor: UIColor.black,
                 hintColor: UIColor.darkGray
             ),
             disabled: InputFieldViewStateAppearance(
                 placeholderColor: UIColor.darkGray,
                 contentBackgroundColor: UIColor.secondarySystemBackground,
                 textFieldTextColor: UIColor.darkGray,
-                borderColor: UIColor.gray,
+                borderColor: UIColor.systemGray2,
                 hintColor: UIColor.darkGray
             ),
             failed: InputFieldViewStateAppearance(
@@ -52,8 +52,53 @@ extension InputFieldView {
             )
         )
 
-        InputFieldView.defaultAppearance = customAppearance
+        InputFieldView.defaultAppearance = globalAppearance
     }
+
+}
+
+extension InputFieldAppearance {
+
+    static let custom = InputFieldAppearance(
+        titleFont: UIFont.preferredFont(for: .title2, weight: .regular, defaultSize: 20),
+        titleColor: UIColor.brown,
+        textFieldTintColor: UIColor.brown,
+        textFieldFont: UIFont.preferredFont(for: .title2, weight: .regular, defaultSize: 30.0),
+        hintFont: UIFont.preferredFont(for: .title2, weight: .thin, defaultSize: 20.0),
+        borderWidth: 3,
+        cornerRadius: 20,
+        height: 56,
+        eyeImageHidden: UIImage(systemName: "eye"),
+        eyeImageVisible: UIImage(systemName: "eye.slash"),
+        enabled: InputFieldViewStateAppearance(
+            placeholderColor: UIColor.green.withAlphaComponent(0.5),
+            contentBackgroundColor: UIColor.yellow.withAlphaComponent(0.1),
+            textFieldTextColor: UIColor.green,
+            borderColor: UIColor.systemMint,
+            hintColor: UIColor.darkGray
+        ),
+        selected: InputFieldViewStateAppearance(
+            placeholderColor: UIColor.green.withAlphaComponent(0.5),
+            contentBackgroundColor: UIColor.yellow.withAlphaComponent(0.1),
+            textFieldTextColor: UIColor.green,
+            borderColor: UIColor.green,
+            hintColor: UIColor.darkGray
+        ),
+        disabled: InputFieldViewStateAppearance(
+            placeholderColor: UIColor.darkGray,
+            contentBackgroundColor: UIColor.secondarySystemBackground,
+            textFieldTextColor: UIColor.green.withAlphaComponent(0.5),
+            borderColor: UIColor.systemMint.withAlphaComponent(0.2),
+            hintColor: UIColor.darkGray
+        ),
+        failed: InputFieldViewStateAppearance(
+            placeholderColor: UIColor.darkGray,
+            contentBackgroundColor: UIColor.tertiarySystemBackground,
+            textFieldTextColor:  UIColor.green,
+            borderColor: UIColor.purple,
+            hintColor: UIColor.systemRed
+        )
+    )
 
 }
 

--- a/GoodSwiftUI-Sample/GoodSwiftUI-Sample/Screens/InputFieldSampleView.swift
+++ b/GoodSwiftUI-Sample/GoodSwiftUI-Sample/Screens/InputFieldSampleView.swift
@@ -102,6 +102,7 @@ extension InputFieldSampleView {
     private var nameInputField: some View {
         // Text field
         InputField(text: $name, title: "Name", placeholder: "Jožko", hint: "Text is limited to 10 characters")
+            .inputFieldStyle(.custom)
 
         // "Continue" keyboard action button
             .inputFieldTraits(returnKeyType: .continue)

--- a/Sources/GRInputField/SwiftUI/InputField.swift
+++ b/Sources/GRInputField/SwiftUI/InputField.swift
@@ -42,6 +42,9 @@ public struct InputField<LeftView: View, RightView: View>: UIViewRepresentable {
     private var resignAction: MainClosure?
     private var editingChangedAction: MainClosure?
 
+    /// Change appearance with `.inputFieldStyle()` modifier
+    private var customAppearance: InputFieldAppearance?
+
     // MARK: - Initialization
 
     public init(
@@ -170,7 +173,7 @@ public struct InputField<LeftView: View, RightView: View>: UIViewRepresentable {
             traits: traits
         )
 
-        view.setup(with: model)
+        view.setup(with: model, customAppearance: customAppearance)
         view.attachTextFieldDelegate(context.coordinator)
 
         view.setValidationCriteria(criteria)
@@ -387,6 +390,12 @@ public extension InputField {
     func validationCriteria(@ValidatorBuilder _ criteria: @escaping MainSupplier<Validator>) -> Self {
         var modifiedSelf = self
         modifiedSelf.criteria = criteria
+        return modifiedSelf
+    }
+
+    func inputFieldStyle(_ appearance: InputFieldAppearance) -> Self {
+        var modifiedSelf = self
+        modifiedSelf.customAppearance = appearance
         return modifiedSelf
     }
 

--- a/Sources/GRInputField/UIKit/InputFieldView.swift
+++ b/Sources/GRInputField/UIKit/InputFieldView.swift
@@ -142,8 +142,9 @@ public class InputFieldView: UIView {
         }
     }
 
+    /// Appearance can be set globally using `configureAppearance()` by modifying the `defaultAppearance`,
+    /// or locally by sending an appearance in `setup(with: Model, customAppearance: InputFieldAppearance?)`.
     open var standardAppearance: InputFieldAppearance = defaultAppearance
-
     public static var defaultAppearance: InputFieldAppearance = .default
 
     // MARK: - Combine
@@ -563,7 +564,12 @@ public extension InputFieldView {
 
     var isSelected: Bool { textField.isSelected }
 
-    func setup(with model: Model) {
+    func setup(with model: Model, customAppearance: InputFieldAppearance? = nil) {
+        if let customAppearance {
+            standardAppearance = customAppearance
+            setupAppearance()
+        }
+
         /// Traits
         setupTraits(traits: model.traits ?? .default)
         setupToolbarIfNeeded(traits: model.traits ?? .default)


### PR DESCRIPTION
Changes:
- Added a configuration to support custom appearance for `InputField` by using `.inputFieldStyle(.custom)` modifier.
- Logic to setup a global appearance with `configureAppearance` remains.

Screenshots: 
https://github.com/user-attachments/assets/223a842b-2b1d-4e71-a8ad-7837e49e74b7

